### PR TITLE
Sync cookies from WebView to proxy

### DIFF
--- a/src/ios/WebviewProxy.m
+++ b/src/ios/WebviewProxy.m
@@ -18,7 +18,6 @@
 }
 
 - (BOOL) overrideSchemeTask: (id <WKURLSchemeTask>)urlSchemeTask {
-    NSString * startPath = @"";
     NSURL * url = urlSchemeTask.request.URL;
     NSDictionary * header = urlSchemeTask.request.allHTTPHeaderFields;
     NSMutableString * stringToLoad = [NSMutableString string];
@@ -26,91 +25,86 @@
     NSString * method = urlSchemeTask.request.HTTPMethod;
     NSData * body = urlSchemeTask.request.HTTPBody;
     
+    // Request should be handled by this plugin if the url contains the proxy path
     if ([stringToLoad hasPrefix:@"/_http_proxy_"]||[stringToLoad hasPrefix:@"/_https_proxy_"]) {
-        
-        
+        // Firt sync all cookies from the WKHTTPCookieStore to the NSHTTPCookieStorage..
+        // .. to solve make cookies set in the main or IAB webview available for proxy requests
         WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
-            WKHTTPCookieStore* cookieStore = dataStore.httpCookieStore;
-            int secondsToKeep = 60*60*24*90;
-            [cookieStore getAllCookies:^(NSArray* cookies) {
-                NSHTTPCookie* cookie;
-                for(cookie in cookies) {
-                    NSMutableDictionary* cookieDict = [cookie.properties mutableCopy];
-                    [cookieDict removeObjectForKey:NSHTTPCookieDiscard]; // Remove the discard flag. If it is set (even to false), the expires date will NOT be kept.
-                    if (![cookieDict objectForKey:NSHTTPCookieExpires]) { // If the cookie doesn't have an expiration date, set it to the maximum value. Otherwise, keep the existing value.
-                        [cookieDict setObject:[NSDate dateWithTimeIntervalSinceNow:secondsToKeep] forKey:NSHTTPCookieExpires]; // Expires in 90 days. Only applies to version 0 cookies (rare).
-                    }
-                    if (![cookieDict objectForKey:NSHTTPCookieMaximumAge]) { // If the cookie doesn't have a max age, set it to the maximum value. Otherwise, keep the existing value.
-                        [cookieDict setObject:[NSString stringWithFormat:@"%d",secondsToKeep] forKey:NSHTTPCookieMaximumAge]; // Expires in 90 days. Only applies to version 1 cookies.
-                    }
-                    NSHTTPCookie* newCookie = [NSHTTPCookie cookieWithProperties:cookieDict];
-                    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:newCookie];
-                    
-                }
-            }];
-        
-        
-        if(url.query) {
-            [stringToLoad appendString:@"?"];
-            [stringToLoad appendString:url.query];
-        }                startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_http_proxy_" withString:@"http://"];
-        startPath = [startPath stringByReplacingOccurrencesOfString:@"/_https_proxy_" withString:@"https://"];
-        NSURL * requestUrl = [NSURL URLWithString:startPath];
-        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-        [request setHTTPMethod:method];
-        [request setURL:requestUrl];
-        if (body) {
-            [request setHTTPBody:body];
-        }
-        [request setAllHTTPHeaderFields:header];
-        [request setHTTPShouldHandleCookies:YES];
-        [request setTimeoutInterval:1800];
-        
-        [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            if(error && (self.stoppedTasks == nil || ![self.stoppedTasks containsObject:urlSchemeTask])) {
-                @try {
-                    NSLog(@"WebviewProxy error: %@", error);
-                    [urlSchemeTask didFailWithError:error];
-                    return;
-                } @catch (NSException *exception) {
-                    NSLog(@"WebViewProxy send error exception: %@", exception.debugDescription);
-                }
-            }
-            
-            // set cookies to WKWebView
-            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
-            if(httpResponse) {
-                NSArray* cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:[httpResponse allHeaderFields] forURL:response.URL];
-                [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:httpResponse.URL mainDocumentURL:nil];
-                cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
+        WKHTTPCookieStore* cookieStore = dataStore.httpCookieStore;
+        [cookieStore getAllCookies:^(NSArray* cookies) {
+            NSHTTPCookie* cookie;
+            for(cookie in cookies) {
+                NSMutableDictionary* cookieDict = [cookie.properties mutableCopy];
+                [cookieDict removeObjectForKey:NSHTTPCookieDiscard]; // Remove the discard flag. If it is set (even to false), the expires date will NOT be kept.
+                NSHTTPCookie* newCookie = [NSHTTPCookie cookieWithProperties:cookieDict];
+                [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:newCookie];
                 
-                for (NSHTTPCookie* c in cookies)
-                {
-                    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
-                        //running in background thread is necessary because setCookie otherwise fails
-                        dispatch_async(dispatch_get_main_queue(), ^(void){
-                            [cookieStore setCookie:c completionHandler:nil];
-                        });
-                    });
-                };
             }
             
-            // Do not use urlSchemeTask if it has been closed in stopURLSchemeTask. Otherwise the app will crash.
-            @try {
-                if(self.stoppedTasks == nil || ![self.stoppedTasks containsObject:urlSchemeTask]) {
-                    [urlSchemeTask didReceiveResponse:response];
-                    [urlSchemeTask didReceiveData:data];
-                    [urlSchemeTask didFinish];
-                } else {
-                    NSLog(@"Task stopped %@", startPath);
-                }
-            } @catch (NSException *exception) {
-                NSLog(@"WebViewProxy send response exception: %@", exception.debugDescription);
-            } @finally {
-                // Cleanup
-                [self.stoppedTasks removeObject:urlSchemeTask];
+            NSString * startPath = @"";
+            if(url.query) {
+                [stringToLoad appendString:@"?"];
+                [stringToLoad appendString:url.query];
+            }                startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_http_proxy_" withString:@"http://"];
+            startPath = [startPath stringByReplacingOccurrencesOfString:@"/_https_proxy_" withString:@"https://"];
+            NSURL * requestUrl = [NSURL URLWithString:startPath];
+            NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+            [request setHTTPMethod:method];
+            [request setURL:requestUrl];
+            if (body) {
+                [request setHTTPBody:body];
             }
-        }] resume];
+            [request setAllHTTPHeaderFields:header];
+            [request setHTTPShouldHandleCookies:YES];
+            [request setTimeoutInterval:1800];
+            
+            [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if(error && (self.stoppedTasks == nil || ![self.stoppedTasks containsObject:urlSchemeTask])) {
+                    @try {
+                        NSLog(@"WebviewProxy error: %@", error);
+                        [urlSchemeTask didFailWithError:error];
+                        return;
+                    } @catch (NSException *exception) {
+                        NSLog(@"WebViewProxy send error exception: %@", exception.debugDescription);
+                    }
+                }
+                
+                // Copy cookies from the native requests cookie storage to the webviews cookie storage
+                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+                if(httpResponse) {
+                    NSArray* cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:[httpResponse allHeaderFields] forURL:response.URL];
+                    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookies:cookies forURL:httpResponse.URL mainDocumentURL:nil];
+                    cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
+                    
+                    for (NSHTTPCookie* c in cookies)
+                    {
+                        dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+                            //running in background thread is necessary because setCookie otherwise fails
+                            dispatch_async(dispatch_get_main_queue(), ^(void){
+                                [cookieStore setCookie:c completionHandler:nil];
+                            });
+                        });
+                    };
+                }
+                
+                // Do not use urlSchemeTask if it has been closed in stopURLSchemeTask. Otherwise the app will crash.
+                @try {
+                    if(self.stoppedTasks == nil || ![self.stoppedTasks containsObject:urlSchemeTask]) {
+                        [urlSchemeTask didReceiveResponse:response];
+                        [urlSchemeTask didReceiveData:data];
+                        [urlSchemeTask didFinish];
+                    } else {
+                        NSLog(@"Task stopped %@", startPath);
+                    }
+                } @catch (NSException *exception) {
+                    NSLog(@"WebViewProxy send response exception: %@", exception.debugDescription);
+                } @finally {
+                    // Cleanup
+                    [self.stoppedTasks removeObject:urlSchemeTask];
+                }
+            }] resume];
+        }];
+        
         return  YES;
     }
     

--- a/src/ios/WebviewProxy.m
+++ b/src/ios/WebviewProxy.m
@@ -8,6 +8,8 @@
 
 @property (nonatomic) NSMutableArray* stoppedTasks;
 
+- (void)clearCookie:(CDVInvokedUrlCommand*)command;
+
 @end
 
 @implementation WebviewProxy
@@ -114,6 +116,21 @@
 - (void) stopSchemeTask: (id <WKURLSchemeTask>)urlSchemeTask {
     NSLog(@"Stop WevViewProxy %@", urlSchemeTask.debugDescription);
     [self.stoppedTasks addObject:urlSchemeTask];
+}
+
+- (void) clearCookie:(CDVInvokedUrlCommand*)command {
+    CDVPluginResult* pluginResult = nil;
+
+    WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
+    WKHTTPCookieStore* cookieStore = dataStore.httpCookieStore;
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> * cookies) {
+        for (NSHTTPCookie* _c in cookies)
+        {
+            [cookieStore deleteCookie:_c completionHandler:nil];
+        };
+    }];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 @end


### PR DESCRIPTION
> This PR has been created by @thorsten-wolf-neptune and @NiklasMerz during a debuggin session.

# Description

This PR sync the cookies from the WKWebViews Cookie Storage to the `NSHTTPCookieStorage` to make cookies set in the WebView or IAB available in the proxy requests. This happens before the proxy request goes out.

Cookies from the `NSHTTPCookieStorage` already get synced after every response to the `WKHTTPCookieStore`.

# Testing

This can be tested with a test app: https://github.com/NiklasMerz/cors-cookie-proxy-test-app

This solved following use case:

* Open IAB and set cookie with second fetch button for niklas.merz.dev origin
-> Cookie is now set in `WKHTTPCookieStore`
* Close IAB and make request with proxy to origin from main webview and see response with no cookie
-> Cookie is not set for proxy request because cookies from the `WKHTTPCookieStore` never go into the `NSHTTPCookieStorage` the proxy uses.


Built with help from this comment: https://github.com/apache/cordova-plugin-inappbrowser/issues/753#issuecomment-872372518
